### PR TITLE
Fix HTML Escape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+ - gem install bundler
 rvm:
  - 1.8.7
  - 1.9.3

--- a/lib/hparser/html.rb
+++ b/lib/hparser/html.rb
@@ -326,7 +326,7 @@ module HParser
       include Html
       def to_html
         url = "http://chart.apis.google.com/chart?cht=tx&chf=bg,s,00000000&chl=" + CGI.escape(self.text)
-        %(<img src="#{url}" class="tex" alt="#{escape(self.text)}">)
+        %(<img src="#{escape(url)}" class="tex" alt="#{escape(self.text)}">)
       end
     end
 

--- a/lib/hparser/html.rb
+++ b/lib/hparser/html.rb
@@ -289,11 +289,11 @@ module HParser
       def to_html
         if @bookmark then
             require 'uri'
-            enc_url = URI.encode(url)
+            enc_url = escape(URI.encode(url))
             bookmark = %( <a href="http://b.hatena.ne.jp/entry/#{enc_url}" class="http-bookmark">) + 
                        %(<img src="http://b.hatena.ne.jp/entry/image/#{enc_url}" alt="" class="http-bookmark"></a>)
         end
-        %(<a href="#{self.url}">#{escape(self.title)}</a>#{bookmark})
+        %(<a href="#{escape(self.url)}">#{escape(self.title)}</a>#{bookmark})
       end
     end
 

--- a/lib/hparser/html.rb
+++ b/lib/hparser/html.rb
@@ -4,6 +4,8 @@
 # This file define +to_html+. +to_html+ is convert hatena format to html.
 #
 
+require 'cgi'
+
 module HParser
   # This module provide +to_html+ method.
   # This method is intended to convert  hatena format to html format.
@@ -39,15 +41,8 @@ module HParser
       %(<#{html_tag}>#{content}</#{html_tag}>)
     end
 
-    ESCAPE_TABLE = {
-      '&' => '&amp;',
-      '"' => '&quot;',
-      '<' => '&lt;',
-      '>' => '&gt;'
-    }
-
     def escape(str)
-      str.gsub(/[&"<>]/n) {|c| ESCAPE_TABLE[c] }
+      CGI.escapeHTML(str)
     end
   end
 
@@ -291,7 +286,6 @@ module HParser
 
     class Url
       include Html
-      require "cgi"
       def to_html
         if @bookmark then
             require 'uri'
@@ -299,7 +293,7 @@ module HParser
             bookmark = %( <a href="http://b.hatena.ne.jp/entry/#{enc_url}" class="http-bookmark">) + 
                        %(<img src="http://b.hatena.ne.jp/entry/image/#{enc_url}" alt="" class="http-bookmark"></a>)
         end
-        %(<a href="#{self.url}">#{CGI.escapeHTML(self.title)}</a>#{bookmark})
+        %(<a href="#{self.url}">#{escape(self.title)}</a>#{bookmark})
       end
     end
 
@@ -329,10 +323,10 @@ module HParser
     end
 
     class Tex
+      include Html
       def to_html
-        require "cgi"
         url = "http://chart.apis.google.com/chart?cht=tx&chf=bg,s,00000000&chl=" + CGI.escape(self.text)
-        %(<img src="#{url}" class="tex" alt="#{CGI.escapeHTML(self.text)}">)
+        %(<img src="#{url}" class="tex" alt="#{escape(self.text)}">)
       end
     end
 

--- a/lib/hparser/html.rb
+++ b/lib/hparser/html.rb
@@ -279,8 +279,13 @@ module HParser
 
   module Inline
     class Text
+      include Html
       def to_html
-        self.text
+        # escape < > & " except for HTML tag and HTML entity
+        tag_regex = /(<\/?[a-z]+(?:\s[^>]+)?\/?>|&#\d+;|&#x[0-9a-z]+;|&[a-z]+;)/i
+        self.text.split(tag_regex).map {|e|
+          e.match(tag_regex) ? e : escape(e)
+        }.join
       end
     end
 

--- a/test/test_inline_html.rb
+++ b/test/test_inline_html.rb
@@ -40,14 +40,16 @@ class HtmlInlineTest < Test::Unit::TestCase
   def test_url
     assert_html '<a href="http://mzp.sakura.ne.jp">http://mzp.sakura.ne.jp</a>',
                 'http://mzp.sakura.ne.jp'
+    assert_html '<a href="http://example.com/?a=b&amp;c=d">http://example.com/?a=b&amp;c=d</a>',
+                'http://example.com/?a=b&c=d'
     assert_html '<a href="http://example.com/">TITLE</a>',
                 '[http://example.com/:title=TITLE]'
     assert_html '<a href="http://example.com/">A&amp;B</a>',
                 '[http://example.com/:title=A&B]'
-    assert_html '<a href="http://example.com/#a">TITLE</a> ' + 
-                '<a href="http://b.hatena.ne.jp/entry/http://example.com/%23a" class="http-bookmark">' + 
-                '<img src="http://b.hatena.ne.jp/entry/image/http://example.com/%23a" alt="" class="http-bookmark"></a>',
-                '[http://example.com/#a:title=TITLE:bookmark]'
+    assert_html '<a href="http://example.com/?a=b&amp;c=d#a">TITLE</a> ' + 
+                '<a href="http://b.hatena.ne.jp/entry/http://example.com/?a=b&amp;c=d%23a" class="http-bookmark">' + 
+                '<img src="http://b.hatena.ne.jp/entry/image/http://example.com/?a=b&amp;c=d%23a" alt="" class="http-bookmark"></a>',
+                '[http://example.com/?a=b&c=d#a:title=TITLE:bookmark]'
   end
 
   def test_fotolife

--- a/test/test_inline_html.rb
+++ b/test/test_inline_html.rb
@@ -57,7 +57,7 @@ class HtmlInlineTest < Test::Unit::TestCase
   end
 
   def test_tex
-    assert_html '<img src="http://chart.apis.google.com/chart?cht=tx&chf=bg,s,00000000&chl=e%5E%7Bi%5Cpi%7D+%3D+-1"' +
+    assert_html '<img src="http://chart.apis.google.com/chart?cht=tx&amp;chf=bg,s,00000000&amp;chl=e%5E%7Bi%5Cpi%7D+%3D+-1"' +
                 ' class="tex" alt="e^{i\pi} = -1">',
                 '[tex:e^{i\pi} = -1]'
   end

--- a/test/test_inline_html.rb
+++ b/test/test_inline_html.rb
@@ -27,6 +27,10 @@ class HtmlInlineTest < Test::Unit::TestCase
     assert_same '<img src="http://example.com/" />'
     assert_same '<iframe src="http://example.com/"></iframe>'
     assert_same '<a href="http://example.com/"></a>'
+    assert_same '<br/>'
+    assert_same 'a &amp; &#39;b&#x3a;'
+    assert_html 'a &lt; &quot;b&quot; <img src="http://example.com/"/> c &lt;&gt; d',
+                'a < "b" <img src="http://example.com/"/> c <> d'
   end
 
   def test_id


### PR DESCRIPTION
Fix HTML escape in TeX, URL and text format.

(ex1) `[http://example.com/?a=b&c=d:title=TITLE]`

| . | result |
| --- | --- |
| before | `<a href="http://example.com/?a=b&c=d">TITLE</a>` |
| after | `<a href="http://example.com/?a=b&amp;c=d">TITLE</a>` |

(ex2) `a < <b>b</b>`

| . | result |
| --- | --- |
| before | `a < <b>b</b>` |
| after | `a &lt; <b>b</b>` |
